### PR TITLE
Avoid unnecessery rename non-existing folder

### DIFF
--- a/GalleryBehavior.php
+++ b/GalleryBehavior.php
@@ -154,7 +154,7 @@ class GalleryBehavior extends Behavior
     public function afterUpdate()
     {
         $galleryId = $this->getGalleryId();
-        if ($this->_galleryId != $galleryId) {
+        if ($this->_galleryId && ($this->_galleryId != $galleryId)) {
             $dirPath1 = $this->directory . '/' . $this->_galleryId;
             $dirPath2 = $this->directory . '/' . $galleryId;
             rename($dirPath1, $dirPath2);


### PR DESCRIPTION
For save model without any images and save this model again.